### PR TITLE
Dockerize server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+ENV API_KEY=""
+
+CMD ["node", "build/index.js"] 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ npm install --prefix=~/.global-node-modules @ahrefs/mcp@latest -g
 ```
 
 ## Configuration
+
+### NPX
 You can now add the Ahrefs MCP to your favourite AI assistant app by adding the `ahrefs` part to your app's configuration file:
 ```json
 {
@@ -43,6 +45,23 @@ You can now add the Ahrefs MCP to your favourite AI assistant app by adding the 
             }
         }
     }
+}
+```
+
+### Docker
+
+```json
+{
+  "id": "ahrefs-docker",
+  "command": "docker",
+  "args": [
+    "run","--rm","-i",
+    "-e","API_KEY=${API_KEY}",
+    "ahrefs-mcp-server"
+  ],
+  "env": {
+    "API_KEY": "<your-api-key>"
+  }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "type": "module",
     "scripts": {
         "build": "tsc",
+        "build-docker": "docker build -t ahrefs-mcp-server .",
         "start": "npm run build && node build/index.js"
     },
     "keywords": [


### PR DESCRIPTION
## Context
I had issues with running this server because of the global node binary that Claude client app picked up.

Some example errors I got:
```
[MCP Server Error] ReferenceError: AbortController is not defined
    at Server._onrequest 

...

file:///Users/bartkozorog/.npm/_npx/38579/lib/node_modules/@ahrefs/mcp/build/server.js:5310
        const status = axiosError.response?.status;
                                           ^
SyntaxError: Unexpected token '.'
```

## Description

It was way easier to just run the server within docker, so I did that. Submitting this here in case you think it's useful for other users as well.