### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Ahrefs MCP
 A Model Context Protocol server to connect Claude desktop and other compatible AI assistants to Ahrefs.
 
+<a href="https://glama.ai/mcp/servers/@ahrefs/ahrefs-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ahrefs/ahrefs-mcp-server/badge" alt="Ahrefs Server MCP server" />
+</a>
+
 ## Installation
 `npm` commands need to be executed in a terminal:
 - macOS: open the Terminal from your Applications folder


### PR DESCRIPTION
This PR adds a badge for the [Ahrefs MCP Server](https://glama.ai/mcp/servers/@ahrefs/ahrefs-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ahrefs/ahrefs-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ahrefs/ahrefs-mcp-server/badge" alt="Ahrefs Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.